### PR TITLE
Exlude signatures from signed jars

### DIFF
--- a/src/main/kotlin/com/github/mrcjkb/gradle/modulefinder/AutomaticModuleTransform.kt
+++ b/src/main/kotlin/com/github/mrcjkb/gradle/modulefinder/AutomaticModuleTransform.kt
@@ -62,12 +62,15 @@ abstract class AutomaticModuleTransform: TransformAction<TransformParameters.Non
                 return@run manifest
             }
             manifest.mainAttributes.putValue("Automatic-Module-Name", moduleName)
+            val exclude = Regex("^META-INF/[^/]+\\.(SF|RSA|DSA|sf|rsa|dsa)$")
             JarOutputStream(FileOutputStream(moduleJar), manifest).use { outputStream ->
                 var jarEntry = inputStream.nextJarEntry
                 while (jarEntry != null) {
-                    outputStream.putNextEntry(jarEntry)
-                    outputStream.write(inputStream.readAllBytes())
-                    outputStream.closeEntry()
+                    if (!exclude.matches(jarEntry.name)) {
+                        outputStream.putNextEntry(jarEntry)
+                        outputStream.write(inputStream.readAllBytes())
+                        outputStream.closeEntry()
+                    }
                     jarEntry = inputStream.nextJarEntry
                 }
             }


### PR DESCRIPTION
When transforming a signed jar we need to make sure the signature is removed when the manifest is modified.
Otherwise we can get errors like this:
```
> Task :my-application:run FAILED
Error occurred during initialization of boot layer
java.lang.module.FindException: Unable to derive module descriptor for ...\.gradle\caches\transforms-3\...\transformed\org.eclipse.paho.client.mqttv3-1.2.5-module.jar
Caused by: java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
```
It might be rare to find a signed jar (without an existing module-info or automatic module name) so here is an example to test with:
[`implementation("org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5")`](https://repo1.maven.org/maven2/org/eclipse/paho/org.eclipse.paho.client.mqttv3/1.2.5/)